### PR TITLE
Using S3 as inbox backend storage

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -9,9 +9,9 @@ help:
 	@echo "where <target> is: 'bootstrap', 'up' 'ps', 'down', 'network' or 'clean'\n"
 
 # If DEPLOY_DEV is yes, we use dummy passwords
-bootstrap-dev: DEV="DEPLOY_DEV=yes "
+bootstrap-dev: DEPLOY_DEV=yes
 .env private/lega.yml private bootstrap bootstrap-dev:
-	@${DEV}bootstrap/run.sh ${ARGS} || { cat private/.err; exit 1; }
+	@bootstrap/run.sh ${ARGS} || { cat private/.err; exit 1; }
 
 
 up: .env private/lega.yml
@@ -19,12 +19,13 @@ up: .env private/lega.yml
 
 clean-volumes:
 	docker volume rm lega_db lega_inbox lega_s3
+	-docker volume rm lega_inbox-s3
 
 ps:
 	@docker-compose ps
 
 down: #.env
-	@[[ -f private/lega.yml ]] && docker-compose down -v || echo "No recipe to bring containers down\nHave you bootstrapped? (ie make bootstrap)"
+	@[[ -f private/lega.yml ]] && docker-compose down -v || echo -e "No recipe to bring containers down\nHave you bootstrapped? (ie make bootstrap)"
 
 clean:
 	rm -rf .env private

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -359,8 +359,8 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     labels:
         lega_label: "finalize"
     volumes:
-       - ./conf.ini:/etc/ega/conf.ini:ro
-       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
+      - ./conf.ini:/etc/ega/conf.ini:ro
+      - ../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -381,9 +381,9 @@ cat >> ${PRIVATE}/lega.yml <<EOF
       - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
       - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
     volumes:
-       - inbox:/ega/inbox
-       - ./conf.ini:/etc/ega/conf.ini:ro
-       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
+      - inbox:/ega/inbox
+      - ./conf.ini:/etc/ega/conf.ini:ro
+      - ../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -437,7 +437,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
        - ./certs/ssl.key:/etc/ega/ssl.key:ro
        - ./pgp/ega.sec:/etc/ega/pgp/ega.sec:ro
        - ./pgp/ega2.sec:/etc/ega/pgp/ega2.sec:ro
-       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
+       - ../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -465,6 +465,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
       - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
     volumes:
       - ./conf.ini:/etc/ega/conf.ini:ro
+      - ../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -540,8 +541,8 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     restart: on-failure:3
     networks:
       - lega
-    # ports:
-    #  - "${DOCKER_PORT_s3_inbox}:9000"
+    ports:
+      - "${DOCKER_PORT_s3_inbox}:9000"
     command: server /data
 EOF
 fi

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -540,8 +540,8 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     restart: on-failure:3
     networks:
       - lega
-    ports:
-      - "${DOCKER_PORT_s3_inbox}:9000"
+    # ports:
+    #  - "${DOCKER_PORT_s3_inbox}:9000"
     command: server /data
 EOF
 fi

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -344,6 +344,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF  # SFTP inbox
     volumes:
       - ./conf.ini:/etc/ega/conf.ini:ro
       - ../images/inbox/entrypoint.sh:/usr/local/bin/entrypoint.sh
+      - ../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
       - inbox:/ega/inbox
 EOF
 fi

--- a/deploy/bootstrap/settings.rc
+++ b/deploy/bootstrap/settings.rc
@@ -23,6 +23,11 @@ PGP_PASSPHRASE=$(generate_password 16)
 S3_ACCESS_KEY=$(generate_password 16)
 S3_SECRET_KEY=$(generate_password 32)
 
+if [[ $INBOX == 'mina' ]]; then # S3 backend for inbox
+S3_ACCESS_KEY_INBOX=$(generate_password 16)
+S3_SECRET_KEY_INBOX=$(generate_password 32)
+fi
+
 LOG_LEVEL=DEBUG
 
 LEGA_PASSWORD=$(generate_password 32)

--- a/deploy/bootstrap/settings.rc
+++ b/deploy/bootstrap/settings.rc
@@ -23,7 +23,8 @@ PGP_PASSPHRASE=$(generate_password 16)
 S3_ACCESS_KEY=$(generate_password 16)
 S3_SECRET_KEY=$(generate_password 32)
 
-if [[ $INBOX == 'mina' ]]; then # S3 backend for inbox
+if [[ ${INBOX_BACKEND} == 's3' ]]; then # S3 backend for inbox
+DOCKER_PORT_s3_inbox=9001
 S3_ACCESS_KEY_INBOX=$(generate_password 16)
 S3_SECRET_KEY_INBOX=$(generate_password 32)
 fi

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -101,7 +101,7 @@ def main(args=None):
     inbox_fs = getattr(storage, CONF.get_value('inbox', 'driver', default='FileStorage'))
     fs = getattr(storage, CONF.get_value('vault', 'driver', default='FileStorage'))
     broker = get_connection('broker')
-    do_work = partial(work, fs(), partial(inbox_fs, 'inbox'), broker.channel())
+    do_work = partial(work, fs('vault','lega'), partial(inbox_fs, 'inbox'), broker.channel())
 
     # upstream link configured in local broker
     consume(do_work, broker, 'files', 'archived')

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -19,7 +19,6 @@ routing key :``archived``.
 
 import sys
 import logging
-from pathlib import Path
 from functools import partial
 
 from legacryptor.crypt4gh import get_header
@@ -101,7 +100,7 @@ def main(args=None):
     inbox_fs = getattr(storage, CONF.get_value('inbox', 'driver', default='FileStorage'))
     fs = getattr(storage, CONF.get_value('vault', 'driver', default='FileStorage'))
     broker = get_connection('broker')
-    do_work = partial(work, fs('vault','lega'), partial(inbox_fs, 'inbox'), broker.channel())
+    do_work = partial(work, fs('vault', 'lega'), partial(inbox_fs, 'inbox'), broker.channel())
 
     # upstream link configured in local broker
     consume(do_work, broker, 'files', 'archived')

--- a/lega/notifications.py
+++ b/lega/notifications.py
@@ -80,7 +80,8 @@ class Forwarder(asyncio.Protocol):
         inbox = self.inbox_location % username
 
         if self.isolation:
-            filepath, filename = (os.path.join(inbox, path.lstrip('/')), path)
+            p = path.lstrip('/')
+            filepath, filename = (os.path.join(inbox, p), p)
         else:
             filepath, filename = (path, path[len(inbox):])
 

--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -57,7 +57,7 @@ def get_connection(domain, blocking=True):
 
 def publish(message, channel, exchange, routing, correlation_id=None):
     """Send a message to the local broker with ``path`` was updated."""
-    LOG.debug(f'Sending {message} to exchange: {exchange} [routing key: {routing}]')
+    LOG.debug(f'Sending to exchange: {exchange} [routing key: {routing}]')
     channel.basic_publish(exchange=exchange,
                           routing_key=routing,
                           body=json.dumps(message),

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -206,7 +206,7 @@ class S3Storage():
         try:
             LOG.debug('Creating "%s" bucket', user)
             self.bucket = user
-            self.s3.create_bucket(Bucket=bucket)
+            self.s3.create_bucket(Bucket=self.bucket)
         except self.s3.exceptions.BucketAlreadyOwnedByYou as e:
             LOG.debug(f'Ignoring ({type(e)}): {e}')
         # No need to close anymore?

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -15,17 +15,17 @@ LOG = logging.getLogger(__name__)
 
 
 class FileStorage():
-    """Vault storage on disk and related I/O."""
+    """Storage on disk and related I/O."""
 
-    def __init__(self):
-        """Initialize backend storage to a POSIX file system's path."""
-        self.vault_area = Path(CONF.get_value('vault', 'location'))
+    def __init__(self, config_section, user):
+        """Initialize backend storage to a POSIX file system."""
+        self.prefix = Path(CONF.get_value(config_section, 'location', raw=True) % user)
 
     def location(self, file_id):
         """Retrieve file location."""
         name = f"{file_id:0>20}"  # filling with zeros, and 20 characters wide
         name_bits = [name[i:i+3] for i in range(0, len(name), 3)]
-        target = self.vault_area.joinpath(*name_bits)
+        target = self.prefix.joinpath(*name_bits)
         target.parent.mkdir(parents=True, exist_ok=True)
         return str(target)
 
@@ -38,9 +38,18 @@ class FileStorage():
     @contextmanager
     def open(self, path, mode='rb'):
         """Open stored file."""
-        f = open(path, mode)
+        fp = self.prefix / path.lstrip('/')
+        f = open(fp, mode)
         yield f
         f.close()
+
+    def exists(self, filepath):
+        """Returns if the path exists."""
+        fp = self.prefix / filepath.lstrip('/')
+        return fp.exists()
+
+    def __str__(self):
+        return self.prefix
 
 
 class S3FileReader(object):
@@ -88,33 +97,6 @@ class S3FileReader(object):
             raise ValueError('Seek before start of file')
         self.loc = nloc
         return self.loc
-
-    # def readline(self, length=-1):
-    #     self._fetch(self.loc, self.loc + 1)
-    #     while True:
-    #         found = self.cache[self.loc - self.start:].find(b'\n') + 1
-    #         if 0 < length < found:
-    #             return self.read(length)
-    #         if found:
-    #             return self.read(found)
-    #         if self.end > self.size:
-    #             return self.read(length)
-    #         self._fetch(self.start, self.end + self.blocksize)
-
-    # def __next__(self):
-    #     out = self.readline()
-    #     if not out:
-    #         raise StopIteration
-    #     return out
-
-    # next = __next__
-
-    # def __iter__(self):
-    #     return self
-
-    # def readlines(self):
-    #     """ Return all lines in a file as a list """
-    #     return list(self)
 
     def read(self, length=-1):
         """Read and return up to size bytes."""
@@ -204,19 +186,17 @@ class S3FileReader(object):
 
 
 class S3Storage():
-    """Vault S3 object storage and related I/O."""
+    """S3 object storage and related I/O."""
 
-    def __init__(self):
+    def __init__(self, config_section, user):
         """Initialize S3 object Storage."""
         import boto3
-
-        endpoint = CONF.get_value('vault', 'url')
-        region = CONF.get_value('vault', 'region')
-        bucket = CONF.get_value('vault', 'bucket', default='lega')
-        access_key = CONF.get_value('vault', 'access_key')
-        secret_key = CONF.get_value('vault', 'secret_key')
+        self.endpoint = CONF.get_value(config_section, 'url')
+        region = CONF.get_value(config_section, 'region')
+        access_key = CONF.get_value(config_section, 'access_key')
+        secret_key = CONF.get_value(config_section, 'secret_key')
         self.s3 = boto3.client('s3',
-                               endpoint_url=endpoint,
+                               endpoint_url=self.endpoint,
                                region_name=region,
                                use_ssl=False,
                                verify=False,
@@ -224,8 +204,8 @@ class S3Storage():
                                aws_secret_access_key=secret_key)
         # LOG.debug(f'S3 client: {self.s3!r}')
         try:
-            LOG.debug('Creating "%s" bucket', bucket)
-            self.bucket = bucket
+            LOG.debug('Creating "%s" bucket', user)
+            self.bucket = user
             self.s3.create_bucket(Bucket=bucket)
         except self.s3.exceptions.BucketAlreadyOwnedByYou as e:
             LOG.debug(f'Ignoring ({type(e)}): {e}')
@@ -247,3 +227,11 @@ class S3Storage():
         f = S3FileReader(self.s3, self.bucket, path, mode=mode)
         yield f
         f.close()
+
+    def exists(self, path):
+        """Returns if the path exists."""
+        resp = self.s3.head_object(Bucket=self.bucket, Key=path)
+        return bool(resp['ContentLength'])
+
+    def __str__(self):
+        return self.endpoint + '/' + self.bucket

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -44,11 +44,12 @@ class FileStorage():
         f.close()
 
     def exists(self, filepath):
-        """Returns if the path exists."""
+        """Return true if the path exists."""
         fp = self.prefix / filepath.lstrip('/')
         return fp.exists()
 
     def __str__(self):
+        """Return inbox prefix."""
         return self.prefix
 
 
@@ -229,9 +230,10 @@ class S3Storage():
         f.close()
 
     def exists(self, path):
-        """Returns if the path exists."""
+        """Return true if the path exists."""
         resp = self.s3.head_object(Bucket=self.bucket, Key=path)
         return bool(resp['ContentLength'])
 
     def __str__(self):
+        """Return endpoint/bucket."""
         return self.endpoint + '/' + self.bucket

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -150,8 +150,8 @@ class S3FileReader(object):
 
     def readinto(self, b):
         """Read bytes into a pre-allocated object b and return the number of bytes read."""
-        data = self.read()
-        datalen = len(data)
+        datalen = len(b)
+        data = self.read(datalen)
         b[:datalen] = data
         return datalen
 

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -117,7 +117,7 @@ def main(args=None):
     chunk_size = CONF.get_value('vault', 'chunk_size', conv=int, default=1 << 22)  # 4 MB
 
     broker = get_connection('broker')
-    do_work = partial(work, chunk_size, store(), broker.channel())
+    do_work = partial(work, chunk_size, store('vault', 'lega'), broker.channel())
 
     consume(do_work, broker, 'archived', 'completed')
 

--- a/tests/_common/mq/get.py
+++ b/tests/_common/mq/get.py
@@ -45,8 +45,8 @@ while True:
         user = data.get('user')
         filepath = data.get('filepath')
         assert( user and filepath ) 
-        if user == args.user and filepath.endswith(args.filepath):  # quick hack to fix the Mina inbox issue with filepaths
-        #if user == args.user and filepath == args.filepath:
+        #if user == args.user and filepath.endswith(args.filepath):  # quick hack to fix the Mina inbox issue with filepaths
+        if user == args.user and filepath == args.filepath:
             correlation_ids.append( (props.correlation_id,message_id) )
     except:
         pass

--- a/tests/integration/inbox.bats
+++ b/tests/integration/inbox.bats
@@ -43,7 +43,7 @@ function teardown() {
     do
 	t=$d/$(uuidgen)
 	touch ${TESTFILES}/$t # some empty files
-	TESTFILES_NAMES+=( "/$t" )
+	TESTFILES_NAMES+=( "$t" )
     done
 
     # Upload them
@@ -77,26 +77,26 @@ function teardown() {
     [ "$status" -eq 0 ]
 
     # Upload it
-    legarun ${LEGA_SFTP} -i ${TESTDATA_DIR}/${TESTUSER}.sec ${TESTUSER}@localhost <<< $"put ${TESTFILES}/${TESTFILE}.c4ga /${TESTFILE}.c4ga"
+    legarun ${LEGA_SFTP} -i ${TESTDATA_DIR}/${TESTUSER}.sec ${TESTUSER}@localhost <<< $"put ${TESTFILES}/${TESTFILE}.c4ga ${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
 
     # Fetch the correlation id for that file (Hint: with user/filepath combination)
-    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
     CORRELATION_ID=$output
 
     # Remove the file
-    legarun ${LEGA_SFTP} -i ${TESTDATA_DIR}/${TESTUSER}.sec ${TESTUSER}@localhost <<< $"rm /${TESTFILE}.c4ga"
+    legarun ${LEGA_SFTP} -i ${TESTDATA_DIR}/${TESTUSER}.sec ${TESTUSER}@localhost <<< $"rm ${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
 
     # Publish the file to simulate a CentralEGA trigger
-    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"/${TESTFILE}.c4ga\"}"
+    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"${TESTFILE}.c4ga\"}"
     legarun ${MQ_PUBLISH} --correlation_id ${CORRELATION_ID} files "$MESSAGE"
     [ "$status" -eq 0 ]
 
     # Check that a message with the above correlation id arrived in the expected queue
     # Waiting 20 seconds.
-    retry_until 0 10 2 ${MQ_GET} v1.files.error "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 10 2 ${MQ_GET} v1.files.error "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
 
 }

--- a/tests/integration/ingestion.bats
+++ b/tests/integration/ingestion.bats
@@ -44,18 +44,18 @@ function lega_ingest {
     [ "$status" -eq 0 ]
 
     # Fetch the correlation id for that file (Hint: with user/filepath combination)
-    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
     CORRELATION_ID=$output
 
     # Publish the file to simulate a CentralEGA trigger
-    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"/${TESTFILE}.c4ga\"}"
+    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"${TESTFILE}.c4ga\"}"
     legarun ${MQ_PUBLISH} --correlation_id ${CORRELATION_ID} files "$MESSAGE"
     [ "$status" -eq 0 ]
 
     # Check that a message with the above correlation id arrived in the expected queue
     # Waiting 20 seconds.
-    retry_until 0 10 10 ${MQ_GET} $queue "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 10 10 ${MQ_GET} $queue "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
 }
 
@@ -102,18 +102,18 @@ function lega_ingest {
     [ "$status" -eq 0 ]
 
     # Fetch the correlation id for that file (Hint: with user/filepath combination)
-    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "/${TESTFILE}.c4ga.2"
+    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "${TESTFILE}.c4ga.2"
     [ "$status" -eq 0 ]
     CORRELATION_ID2=$output
     [ "$CORRELATION_ID" != "$CORRELATION_ID2" ]
 
     # Publish the file to simulate a CentralEGA trigger
-    MESSAGE2="{ \"user\": \"${TESTUSER}\", \"filepath\": \"/${TESTFILE}.c4ga.2\"}"
+    MESSAGE2="{ \"user\": \"${TESTUSER}\", \"filepath\": \"${TESTFILE}.c4ga.2\"}"
     legarun ${MQ_PUBLISH} --correlation_id ${CORRELATION_ID2} files "$MESSAGE2"
     [ "$status" -eq 0 ]
 
     # Check that a message with the above correlation id arrived in the error queue
-    retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "/${TESTFILE}.c4ga.2"
+    retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "${TESTFILE}.c4ga.2"
     [ "$status" -eq 0 ]
 }
 
@@ -140,17 +140,17 @@ function lega_ingest {
     [ "$status" -eq 0 ]
 
     # Fetch the correlation id for that file (Hint: with user/filepath combination)
-    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
     CORRELATION_ID=$output
 
     # Publish the file to simulate a CentralEGA trigger
-    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"/${TESTFILE}.c4ga\"}"
+    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"${TESTFILE}.c4ga\"}"
     legarun ${MQ_PUBLISH} --correlation_id ${CORRELATION_ID} files "$MESSAGE"
     [ "$status" -eq 0 ]
 
     # Check that a message with the above correlation id arrived in the completed queue
-    retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "/${TESTFILE}.c4ga"
+    retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "${TESTFILE}.c4ga"
     [ "$status" -eq 0 ]
 }
 
@@ -200,7 +200,7 @@ function lega_ingest {
 # However, the codebase is old and the correlation ID update is not part of it
 # So, instead, we use the filepath and the username to filter out the messages.
 # When the update is in place, the line
-#     retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "/${TESTFILE}.c4ga"
+#     retry_until 0 100 1 ${MQ_GET} v1.files.error "${TESTUSER}" "${TESTFILE}.c4ga"
 # will be updated with
 #     retry_until 0 10 1 ${MQ_FIND} <queue> ${CORRELATION_ID}
 #

--- a/tests/integration/simple.bats
+++ b/tests/integration/simple.bats
@@ -23,9 +23,9 @@ function setup() {
     LEGA_SFTP="sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P ${INBOX_PORT}"
 }
 
-# function teardown() {
-#     rm -rf ${TESTFILES}
-# }
+function teardown() {
+    rm -rf ${TESTFILES}
+}
 
 # Ingesting a 10MB file
 # ----------------------

--- a/tests/integration/simple.bats
+++ b/tests/integration/simple.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+load ../_common/helpers
+load ../_common/c4gh_generate
+
+# CEGA_CONNECTION and CEGA_USERS_CREDS should be already set,
+# when this script runs
+
+function setup() {
+
+    # Defining the TMP dir
+    TESTFILES=${BATS_TEST_FILENAME}.d
+    mkdir -p "$TESTFILES"
+
+    # Test user
+    TESTUSER=dummy
+
+    # Find inbox port mapping. Usually 2222:9000
+    INBOX_PORT="2222"
+    # legarun docker port inbox 9000
+    # [ "$status" -eq 0 ]
+    # INBOX_PORT=${output##*:}
+    LEGA_SFTP="sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P ${INBOX_PORT}"
+}
+
+# function teardown() {
+#     rm -rf ${TESTFILES}
+# }
+
+# Ingesting a 10MB file
+# ----------------------
+# A message should be found in the completed queue
+
+@test "Ingest properly a test file" {
+    local TESTFILE=$(uuidgen)
+    local size=1
+    local queue=v1.files.completed
+    local inputsource=${4:-/dev/urandom}
+
+    # Generate a random file
+    legarun c4gh_generate $size $inputsource ${TESTFILES}/${TESTFILE}
+    [ "$status" -eq 0 ]
+
+    # Upload it
+    UPLOAD_CMD="put ${TESTFILES}/${TESTFILE}.c4ga /${TESTFILE}.c4ga"
+    legarun ${LEGA_SFTP} -i ${TESTDATA_DIR}/${TESTUSER}.sec ${TESTUSER}@localhost <<< ${UPLOAD_CMD}
+    [ "$status" -eq 0 ]
+
+    # Fetch the correlation id for that file (Hint: with user/filepath combination)
+    retry_until 0 100 1 ${MQ_GET} v1.files.inbox "${TESTUSER}" "${TESTFILE}.c4ga"
+    [ "$status" -eq 0 ]
+    CORRELATION_ID=$output
+
+    # Publish the file to simulate a CentralEGA trigger
+    MESSAGE="{ \"user\": \"${TESTUSER}\", \"filepath\": \"${TESTFILE}.c4ga\"}"
+    legarun ${MQ_PUBLISH} --correlation_id ${CORRELATION_ID} files "$MESSAGE"
+    [ "$status" -eq 0 ]
+
+    # Check that a message with the above correlation id arrived in the expected queue
+    # Waiting 20 seconds.
+    retry_until 0 10 10 ${MQ_GET} $queue "${TESTUSER}" "${TESTFILE}.c4ga"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -2,7 +2,7 @@ import unittest
 from lega.ingest import main, work
 from unittest import mock
 from testfixtures import tempdir
-from pathlib import PosixPath
+# from pathlib import PosixPath
 from . import pgp_data
 from lega.utils.exceptions import FromUser
 
@@ -13,9 +13,10 @@ class testIngest(unittest.TestCase):
     Testing ingestion functionalities.
     """
 
+    @mock.patch('lega.ingest.getattr')
     @mock.patch('lega.ingest.get_connection')
     @mock.patch('lega.ingest.consume')
-    def test_main(self, mock_consume, mock_connection):
+    def test_main(self, mock_consume, mock_connection, mock_getattr):
         """Test main verify, by mocking cosume call."""
         mock_consume.return_value = mock.MagicMock()
         main()
@@ -36,7 +37,7 @@ class testIngest(unittest.TestCase):
         mock_broker.channel.return_value = mock.Mock()
         infile = filedir.write('infile.in', bytearray.fromhex(pgp_data.ENC_FILE))
         data = {'filepath': infile, 'user': 'user_id@elixir-europe.org'}
-        result = work(store, mock_broker, data)
+        result = work(store, store, mock_broker, data)
         mocked = {'filepath': infile, 'user': 'user_id@elixir-europe.org',
                   'file_id': 32,
                   'org_msg': {'filepath': infile, 'user': 'user_id@elixir-europe.org'},
@@ -84,7 +85,7 @@ class testIngest(unittest.TestCase):
         infile = filedir.write('infile.in', bytearray.fromhex(pgp_data.ENC_FILE))
 
         data = {'filepath': infile, 'user': 'user_id@elixir-europe.org'}
-        result = work(store, mock_broker, data)
+        result = work(store, store, mock_broker, data)
         self.assertEqual(None, result)
         mock_set_error.assert_called()
         filedir.cleanup()
@@ -109,7 +110,7 @@ class testIngest(unittest.TestCase):
         infile = filedir.write('infile.in', bytearray.fromhex(pgp_data.ENC_FILE))
 
         data = {'filepath': infile, 'user': 'user_id@elixir-europe.org'}
-        result = work(store, mock_broker, data)
+        result = work(store, store, mock_broker, data)
         self.assertEqual(None, result)
         mock_set_error.assert_called()
         mock_publish.assert_called()

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -23,13 +23,10 @@ class testIngest(unittest.TestCase):
 
     @tempdir()
     @mock.patch('lega.ingest.get_header')
-    @mock.patch('lega.ingest.Path')
     @mock.patch('lega.ingest.db')
-    def test_work(self, mock_db, mock_path, mock_header, filedir):
+    def test_work(self, mock_db, mock_header, filedir):
         """Test ingest worker, should send a messge."""
         # Mocking a lot of stuff, as it is previously tested
-        mock_path = mock.Mock(spec=PosixPath)
-        mock_path.return_value = ''
         mock_header.return_value = b'beginning', b'header'
         mock_db.insert_file.return_value = 32
         store = mock.MagicMock()
@@ -50,13 +47,10 @@ class testIngest(unittest.TestCase):
 
     @tempdir()
     @mock.patch('lega.ingest.get_header')
-    @mock.patch('lega.ingest.Path')
     @mock.patch('lega.ingest.db')
-    def test_db_fail(self, mock_db, mock_path, mock_header, filedir):
+    def test_db_fail(self, mock_db, mock_header, filedir):
         """Test ingest worker, insert_file fails."""
         # Mocking a lot of stuff, as it is previously tested
-        mock_path = mock.Mock(spec=PosixPath)
-        mock_path.return_value = ''
         mock_header.return_value = b'beginning', b'header'
         mock_db.insert_file.side_effect = Exception("Some strange exception")
 
@@ -74,14 +68,11 @@ class testIngest(unittest.TestCase):
 
     @tempdir()
     @mock.patch('lega.ingest.get_header')
-    @mock.patch('lega.ingest.Path')
     @mock.patch('lega.ingest.db')
     @mock.patch('lega.utils.db.set_error')
-    def test_mark_in_progress_fail(self, mock_set_error, mock_db, mock_path, mock_header, filedir):
+    def test_mark_in_progress_fail(self, mock_set_error, mock_db, mock_header, filedir):
         """Test ingest worker, mark_in_progress fails."""
         # Mocking a lot of stuff, as it is previously tested
-        mock_path = mock.Mock(spec=PosixPath)
-        mock_path.return_value = ''
         mock_header.return_value = b'beginning', b'header'
         mock_db.mark_in_progress.side_effect = Exception("Some strange exception")
 
@@ -100,16 +91,13 @@ class testIngest(unittest.TestCase):
 
     @tempdir()
     @mock.patch('lega.ingest.get_header')
-    @mock.patch('lega.ingest.Path')
     @mock.patch('lega.ingest.db')
     @mock.patch('lega.utils.db.set_error')
     @mock.patch('lega.utils.db.get_connection')
     @mock.patch('lega.utils.db.publish')
-    def test_mark_in_progress_fail_with_from_user_error(self, mock_publish, mock_get_connection, mock_set_error, mock_db, mock_path, mock_header, filedir):
+    def test_mark_in_progress_fail_with_from_user_error(self, mock_publish, mock_get_connection, mock_set_error, mock_db, mock_header, filedir):
         """Test ingest worker, mark_in_progress fails."""
         # Mocking a lot of stuff, as it is previously tested
-        mock_path = mock.Mock(spec=PosixPath)
-        mock_path.return_value = ''
         mock_header.return_value = b'beginning', b'header'
         mock_db.mark_in_progress.side_effect = FromUser()
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -54,7 +54,7 @@ class testForwarder(unittest.TestCase):
         self._forwarder.data_received(b'user$file.name$user$/to')
         self._forwarder.send_message.assert_called_with('user', 'file.name')
         self._forwarder.data_received(b'to4.txt$us')
-        self._forwarder.send_message.assert_called_with('user', 'toto4.txt')
+        self._forwarder.send_message.assert_called_with('user', '/toto4.txt')
         self._forwarder.data_received(b'er$test.fi')
         self._forwarder.data_received(b'le$')
         self._forwarder.send_message.assert_called_with('user', 'test.file')

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -54,7 +54,7 @@ class testForwarder(unittest.TestCase):
         self._forwarder.data_received(b'user$file.name$user$/to')
         self._forwarder.send_message.assert_called_with('user', 'file.name')
         self._forwarder.data_received(b'to4.txt$us')
-        self._forwarder.send_message.assert_called_with('user', '/toto4.txt')
+        self._forwarder.send_message.assert_called_with('user', 'toto4.txt')
         self._forwarder.data_received(b'er$test.fi')
         self._forwarder.data_received(b'le$')
         self._forwarder.send_message.assert_called_with('user', 'test.file')


### PR DESCRIPTION
Using S3 as inbox backend storage

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The storage module can read and write to either a POSIX file system or an S3 backend.
Ingestion now reads from an S3 backend in case the `--inbox-backend s3` is passed to the bootstrap script.

### Changes made:
1) Added sections in the bootstrap script to spawn an S3 volume, and a Minio container on it.
2) Adjusted the configurations to make ingest.py point to that backend
3) Fixed a issue in the storage.py latest additions (generating the huge headers)
4) Adjusted the notification message that land in the inbox queue.

### Related issues:
#15 
Fixes the huge header issue (not listed, but still existing)

### Additional information:
Added a simple.bats with only one ingestion of a 1MB test file.
Calling `bats tests/integration/simple.bats` for simplicity and quick checking if it all works.

### Mentions:
@dtitov: You can try that branch with your setup in swarm.
I tried it and ingestion was succesful
@blankdots, @viklund : Could you review the python code, please? 