### PR TITLE
Injecting the local changes into nbis images

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -328,6 +328,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
         lega_label: "finalize"
     volumes:
        - ./conf.ini:/etc/ega/conf.ini:ro
+       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -350,6 +351,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     volumes:
        - inbox:/ega/inbox
        - ./conf.ini:/etc/ega/conf.ini:ro
+       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega
@@ -403,6 +405,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
        - ./certs/ssl.key:/etc/ega/ssl.key:ro
        - ./pgp/ega.sec:/etc/ega/pgp/ega.sec:ro
        - ./pgp/ega2.sec:/etc/ega/pgp/ega2.sec:ro
+       - ./../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega


### PR DESCRIPTION
I understand the `VAULT_..._KEY` discrepency was introduced when the environment variables were renamed.

The code and bootstrap need ajustements, as in PR#26.
However, the setup still uses the nbis images and the code was not injected in them.

With this change, the tests can run with the newly adjusted code, without failing.