### PR TITLE
Pinning the minio version

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -533,7 +533,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     container_name: inbox-s3-backend
     labels:
         lega_label: "inbox-s3-backend"
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-12-19T23-46-24Z
     environment:
       - MINIO_ACCESS_KEY=${S3_ACCESS_KEY_INBOX}
       - MINIO_SECRET_KEY=${S3_SECRET_KEY_INBOX}

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -510,7 +510,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     container_name: vault
     labels:
         lega_label: "vault"
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-12-19T23-46-24Z
     environment:
       - MINIO_ACCESS_KEY=${S3_ACCESS_KEY}
       - MINIO_SECRET_KEY=${S3_SECRET_KEY}


### PR DESCRIPTION
Travis pulls the latest minio image, and our local machines might still use an old (and working) one.

The travis debug mode showed that the XML response from Minio was malformatted
![screen shot 2019-02-08 at 15 42 37](https://user-images.githubusercontent.com/465385/52485258-b9a3b000-2bb8-11e9-8b79-c662d1b1ded9.png)


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation


### Changes made:
Pinned to a working version

### Mentions:
@jbygdell , @viklund : I think that helps solve the Travis differences.