### PR TITLE
Removing audit.sql mentions from bootstrap

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -294,7 +294,6 @@ services:
       - ../images/db/postgresql.conf:/etc/ega/pg.conf:ro
       - ../images/db/main.sql:/docker-entrypoint-initdb.d/main.sql:ro
       - ../images/db/grants.sql:/docker-entrypoint-initdb.d/grants.sql:ro
-      - ../images/db/audit.sql:/docker-entrypoint-initdb.d/audit.sql:ro
       - ../images/db/download.sql:/docker-entrypoint-initdb.d/download.sql:ro
       - ../images/db/ebi.sql:/docker-entrypoint-initdb.d/ebi.sql:ro
       - ../images/db/qc.sql:/docker-entrypoint-initdb.d/qc.sql:ro


### PR DESCRIPTION
This is not harmful to keep it (since it is ignored),
but it causes docker to create a directory on the local file system.
That's a little ugly and this is cleaning it up.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
