### PR TITLE
Fix database view for data out

### DIFF
--- a/deploy/images/db/download.sql
+++ b/deploy/images/db/download.sql
@@ -2,53 +2,35 @@ CREATE SCHEMA local_ega_download;
 
 SET search_path TO local_ega_download;
 
-CREATE TABLE local_ega_download.status (
-        id            INTEGER,
-	code          VARCHAR(32) NOT NULL,
-	description   TEXT,
-	-- contraints
-	PRIMARY KEY(id), UNIQUE (id), UNIQUE (code)
-);
-
-INSERT INTO local_ega_download.status(id,code,description)
-VALUES (10, 'INIT'        , 'Initializing a download request'),
-       (20, 'REENCRYPTING', 'Re-Encrypting the header for a given user'),
-       (30, 'STREAMING'   , 'Streaming file from the Archive'),
-       (40, 'DONE'        , 'Download completed'), -- checksums are in the Crypt4GH formatted file
-                                                   -- and validated by the decryptor
-       (0, 'ERROR'        , 'An Error occured, check the error table');
-
-
-CREATE TABLE local_ega_download.main (
+CREATE TABLE local_ega_download.requests (
    id                 SERIAL, PRIMARY KEY(id), UNIQUE (id),
 
    -- which files was downloaded
    file_id            INTEGER NOT NULL REFERENCES local_ega.main(id), -- No "ON DELETE CASCADE"
+   start_coordinate   BIGINT DEFAULT 0,
+   end_coordinate     BIGINT NULL, -- might be missing
 
-   -- Status/Progress
-   status             VARCHAR NOT NULL REFERENCES local_ega_download.status (code), -- No "ON DELETE CASCADE"
-                      -- DEFAULT 'INIT' ?
+   -- user info
+   user_info         TEXT NULL,
+   client_ip         TEXT NULL,
    
-   -- Stats
-   start_timestamp   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
-   end_timestamp     TIMESTAMP,
-   bytes             INTEGER DEFAULT 0,
-   speed             FLOAT   DEFAULT 0.0, -- bytes per seconds
-
-   -- table logs
-   created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
-   last_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+   created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
 );
 
-
 -- Insert new request, and return some archive information
-CREATE TYPE request_type AS (req_id     INTEGER, -- local_ega_download.main.id%TYPE,
-                             file_id    INTEGER, -- local_ega.archive_files.id%TYPE,
-			     header     TEXT,    -- local_ega.archive_files.header%TYPE,
-			     archive_path TEXT,    -- local_ega.archive_files.archive_file_reference%TYPE,
-			     archive_type local_ega.storage);--local_ega.archive_files.archive_file_type%TYPE);
+CREATE TYPE request_type AS (req_id                    INTEGER,
+                             header                    TEXT,
+			     archive_path                TEXT,
+			     archive_type                local_ega.storage,
+			     file_size                 INTEGER,
+			     unencrypted_checksum      VARCHAR,
+			     unencrypted_checksum_type local_ega.checksum_algorithm);
 
-CREATE FUNCTION make_request(sid local_ega.main.stable_id%TYPE)
+CREATE FUNCTION make_request(sid    local_ega.main.stable_id%TYPE,
+			     uinfo  local_ega_download.requests.user_info%TYPE,
+			     cip    local_ega_download.requests.client_ip%TYPE,
+                             scoord local_ega_download.requests.start_coordinate%TYPE DEFAULT 0,
+                             ecoord local_ega_download.requests.end_coordinate%TYPE DEFAULT NULL)
 RETURNS request_type AS $make_request$
 #variable_conflict use_column
 DECLARE
@@ -57,106 +39,84 @@ DECLARE
      rid  INTEGER;
 BEGIN
 
+     -- Find the file
      SELECT * INTO archive_rec FROM local_ega.archive_files WHERE stable_id = sid LIMIT 1;
 
      IF archive_rec IS NULL THEN
-     	RAISE EXCEPTION 'Archive file not found for stable_id: % ', sid;
+     	RAISE EXCEPTION 'archived file not found for stable_id: % ', sid;
      END IF;
 
-     INSERT INTO local_ega_download.main (file_id, status)
-     VALUES (archive_rec.id, 'INIT')
-     RETURNING local_ega_download.main.id INTO rid;
-
-     req.req_id     := rid;
-     req.file_id    := archive_rec.id;
-     req.header     := archive_rec.header;
-     req.archive_path := archive_rec.archive_file_reference;
-     req.archive_type := archive_rec.archive_file_type;
+     -- New entry, or reuse old entry
+     INSERT INTO local_ega_download.requests (file_id, user_info, client_ip, start_coordinate, end_coordinate)
+     VALUES (archive_rec.file_id, uinfo, cip, scoord, ecoord)
+     ON CONFLICT (id) DO NOTHING
+     RETURNING local_ega_download.requests.id INTO rid;
+     
+     -- result
+     req.req_id                    := rid;
+     req.header                    := archive_rec.header;
+     req.archive_path              := archive_rec.archive_path;
+     req.archive_type              := archive_rec.archive_type;
+     req.file_size                 := archive_rec.archive_filesize;
+     req.unencrypted_checksum      := archive_rec.unencrypted_checksum;
+     req.unencrypted_checksum_type := archive_rec.unencrypted_checksum_type;
      RETURN req;
 END;
 $make_request$ LANGUAGE plpgsql;
 
--- When there is an updated, remember the timestamp
-CREATE FUNCTION download_updated()
-RETURNS TRIGGER AS $download_updated$
-BEGIN
-     NEW.last_modified = clock_timestamp();
-     RETURN NEW;
-END;
-$download_updated$ LANGUAGE plpgsql;
 
-CREATE TRIGGER download_updated AFTER UPDATE ON local_ega_download.main FOR EACH ROW EXECUTE PROCEDURE download_updated();
+CREATE TABLE local_ega_download.success (
+   id          SERIAL, PRIMARY KEY(id), UNIQUE (id),
+
+   -- which requested file it was
+   req_id      INTEGER NOT NULL REFERENCES local_ega_download.requests(id), -- No "ON DELETE CASCADE"
+
+   -- Stats
+   bytes       BIGINT DEFAULT 0,
+   speed       FLOAT  DEFAULT 0.0, -- bytes per seconds
+
+   -- table logs
+   occured_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
 
 
 -- Mark a download as complete, and calculate the speed
-CREATE FUNCTION download_complete(reqid  local_ega_download.main.id%TYPE,
-				  dlsize local_ega_download.main.bytes%TYPE)
-RETURNS void AS $download_complete$
-DECLARE
-     fid local_ega.main.id%TYPE;
-     curr_timestamp TIMESTAMP;
+CREATE FUNCTION download_complete(rid    local_ega_download.requests.id%TYPE,
+       				  dlsize local_ega_download.success.bytes%TYPE,
+          			  s      local_ega_download.success.speed%TYPE)
+RETURNS void AS $insert_success$
 BEGIN
-     curr_timestamp := clock_timestamp();
-     UPDATE local_ega_download.main
-     SET status = 'DONE',
-         end_timestamp = curr_timestamp,
-         bytes = dlsize,
-	 speed = dlsize / extract( epoch from (curr_timestamp - start_timestamp)) -- extract (epoch for interval) = elapsed seconds
-                                                                                  -- now pray for no div by zero
-     WHERE id = reqid
-     RETURNING file_id INTO fid;
-
-     -- turn off active errors
-     UPDATE local_ega_download.main_errors SET active = FALSE WHERE file_id = fid;
+     INSERT INTO local_ega_download.success(req_id,bytes,speed)
+     VALUES(rid,dlsize,s);
 END;
-$download_complete$ LANGUAGE plpgsql;
+$insert_success$ LANGUAGE plpgsql;
 
 
 -- ##################################################
 --                      ERRORS
 -- ##################################################
-CREATE TABLE local_ega_download.main_errors (
-       id          SERIAL, PRIMARY KEY(id), UNIQUE (id),
-       active      BOOLEAN NOT NULL DEFAULT TRUE,
-       file_id     INTEGER NOT NULL REFERENCES local_ega.main(id), -- ON DELETE CASCADE,
-       req_id      INTEGER NOT NULL REFERENCES local_ega_download.main(id), -- ON DELETE CASCADE,
-			
-       code        TEXT NOT NULL,
-       description TEXT NOT NULL,
+CREATE TABLE local_ega_download.errors (
+   id          SERIAL, PRIMARY KEY(id), UNIQUE (id),
+   req_id      INTEGER NOT NULL REFERENCES local_ega_download.requests(id), -- ON DELETE CASCADE,
 
-       client_ip   TEXT, -- where from
-       hostname    TEXT, -- where it happened
+   code        TEXT NOT NULL,
+   description TEXT NOT NULL,
 
-       -- table logs
-       occured_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+   -- where it happened
+   hostname    TEXT,
+
+   -- table logs
+   occured_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
 );
 
--- Just showing the current/active errors
-CREATE VIEW local_ega_download.errors AS
-SELECT id, code, description, client_ip, hostname, occured_at FROM local_ega_download.main_errors
-WHERE active = TRUE;
-
-CREATE FUNCTION insert_error(req_id    local_ega_download.main.id%TYPE,
-                             h         local_ega_download.errors.hostname%TYPE,
-                             etype     local_ega_download.errors.code%TYPE,
-                             msg       local_ega_download.errors.description%TYPE,
-                             client_ip local_ega_download.errors.client_ip%TYPE)
-RETURNS void AS $download_error$
-DECLARE
-     fid local_ega_download.main.file_id%TYPE;
+CREATE FUNCTION insert_error(rid    local_ega_download.requests.id%TYPE,
+			     h      local_ega_download.errors.hostname%TYPE,
+                             etype  local_ega_download.errors.code%TYPE,
+                             msg    local_ega_download.errors.description%TYPE)
+RETURNS void AS $insert_error$
 BEGIN
-
-     UPDATE local_ega_download.main
-     SET status = 'ERROR'
-     WHERE id = req_id
-     RETURNING file_id INTO fid;
-		 
-     IF fid IS NULL THEN
-     	RAISE EXCEPTION 'Request id not found: %', req_id;
-     END IF;
-
-     INSERT INTO local_ega_download.main_errors (file_id,req_id,hostname,code,description,client_ip)
-     VALUES (fid,req_id, h, etype, msg, client_ip);
-
+     INSERT INTO local_ega_download.errors (req_id,hostname,code,description)
+     VALUES (rid, h, etype, msg);
 END;
-$download_error$ LANGUAGE plpgsql;
+$insert_error$ LANGUAGE plpgsql;
+

--- a/deploy/images/db/grants.sql
+++ b/deploy/images/db/grants.sql
@@ -17,13 +17,13 @@ GRANT USAGE ON SCHEMA local_ega TO lega_in, lega_out;
 GRANT ALL PRIVILEGES ON ALL TABLES    IN SCHEMA local_ega TO lega_in; -- Read/Write access on local_ega.* for lega_in
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA local_ega TO lega_in; -- Don't forget the sequences
 GRANT SELECT ON local_ega.archive_files  TO lega_out;                    -- Read-Only access for lega_out
-GRANT SELECT ON local_ega.ebi_files    TO lega_out;                    -- Used by EBI
-GRANT SELECT ON local_ega.index_files  TO lega_out;                    -- Used by EBI
-GRANT SELECT ON local_ega.file2dataset TO lega_out;                    -- Used by EBI
-GRANT SELECT ON local_ega.event        TO lega_out;                    -- Used by EBI
-GRANT SELECT ON local_ega.download_log TO lega_out;                    -- Used by EBI
 
 -- Set up rights access for audit schema
 GRANT USAGE ON SCHEMA local_ega_download TO lega_out;
 GRANT ALL PRIVILEGES ON ALL TABLES    IN SCHEMA local_ega_download TO lega_out; -- Read/Write on audit.* for lega_out
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA local_ega_download TO lega_out; -- Don't forget the sequences
+
+-- Set up rights access for local_ega_ebi schema
+GRANT USAGE ON SCHEMA local_ega_ebi TO lega_out;
+GRANT ALL PRIVILEGES ON ALL TABLES    IN SCHEMA local_ega_ebi TO lega_out;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA local_ega_ebi TO lega_out;

--- a/deploy/images/db/main.sql
+++ b/deploy/images/db/main.sql
@@ -277,14 +277,17 @@ CREATE TRIGGER mark_ready
 
 -- View on the archive files
 CREATE VIEW local_ega.archive_files AS
-SELECT id,
-       stable_id,
-       archive_file_reference,
-       archive_file_type,
-       header
+SELECT id                        AS file_id
+     , stable_id                 AS stable_id
+     , archive_file_reference      AS archive_path
+     , archive_file_type           AS archive_type
+     , archive_file_size           AS archive_filesize
+     , archive_file_checksum       AS unencrypted_checksum
+     , archive_file_checksum_type  AS unencrypted_checksum_type
+     , header                    AS header
+     , version                   AS version
 FROM local_ega.main
 WHERE status = 'READY';
-
 -- ##########################################################################
 --                   About the encryption
 -- ##########################################################################


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This commit changes the views from LocalEga to be compatible with
the current data-out code

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
This PR fixes #34 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
I cannot include any tests right now until other issues are fixed. Also there is a new issue for the data out code because to access the s3 backend it uses the fileid instead of the filepath (https://github.com/EGA-archive/ega-data-api/issues/101)
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
