### PR TITLE
Hotfix/posix

### DIFF
--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -25,8 +25,7 @@ class FileStorage():
         """Retrieve file location."""
         name = f"{file_id:0>20}"  # filling with zeros, and 20 characters wide
         name_bits = [name[i:i+3] for i in range(0, len(name), 3)]
-        target = self.prefix.joinpath(*name_bits)
-        target.parent.mkdir(parents=True, exist_ok=True)
+        target = Path('/').joinpath(*name_bits)
         return str(target)
 
     def filesize(self, path):
@@ -35,9 +34,11 @@ class FileStorage():
 
     def copy(self, fileobj, location):
         """Copy file object at a specific location."""
-        with open(location, 'wb') as h:
+        target = self.prefix / location.lstrip('/')
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, 'wb') as h:
             shutil.copyfileobj(fileobj, h)
-        return os.stat(location).st_size
+        return self.filesize(location)
 
     @contextmanager
     def open(self, path, mode='rb'):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -30,14 +30,14 @@ class TestFileStorage(unittest.TestCase):
     def test_location(self):
         """Test file location."""
         result = self._store.location('12')
-        self.assertEqual(os.path.join(self.outputdir, 'lega', '000', '000', '000', '000', '000', '000', '12'), result)
+        self.assertEqual(os.path.join('/', '000', '000', '000', '000', '000', '000', '12'), result)
 
     def test_copy(self):
         """Test copy file."""
         path = self._dir.write('output/lega/test.file', 'data1'.encode('utf-8'))
         path1 = self._dir.write('output/lega/test1.file', ''.encode('utf-8'))
         result = self._store.copy(open(path, 'rb'), path1)
-        self.assertEqual(os.stat(path1).st_size, result)
+        self.assertEqual(os.stat(path).st_size, result)
 
     def test_open(self):
         """Test open file."""


### PR DESCRIPTION
Resolving #45 and #46 

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

### Changes made:
* Adding a `--archive-backend` switch to the bootstrap (keeping `s3` as default, so nothing changes).
* File paths in the DB are now stored without the prefix where the archive is mounted. The latter is a configuration setting.
* The archive volume is now only a volume mount. I used `private/data/archive`. This solves issue #45 because the owner is then `lega`. When docker-compose creates the volume, it uses root as the owner, causing `lega` not to have access to the mountpoint.

### Related issues:
#45 and #46 

### Additional information:
It is worth solving #45 in another way and use the different driver options available from docker.
The `local` driver can apparently use the same options as the `mount` command. So I tried `gid=lega,setgid=lega,noexec,nodev` before reverting to the simpler solution above. Worth noting though.

### Mentions:
@blankdots @viklund 