### PR TITLE
Remove jinja as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pika==0.12.0
 aiohttp==3.3.2
-aiohttp-jinja2==0.13.0
 sphinx_rtd_theme
 cryptography==2.3.1
 pgpy
@@ -18,7 +17,7 @@ docutils==0.14
 future==0.17.1
 idna==2.8
 imagesize==1.1.0
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.1.0
 packaging==19.0
 Pygments==2.3.1


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
Addresses this:
![image](https://user-images.githubusercontent.com/47524/56110112-f3e45180-5f5b-11e9-8f81-280f79bb926d.png)

Also `aiohttp-jinja2` does not seem to be used anywhere, was used in fake CEGA-users.

### Changes made:
1. from `requirements.txt` removed `aiohttp-jinja2`
2. updated `Jinja2` to `2.10.1` - seems to be installed by a dependent library
