### PR TITLE
Update urlib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ six==1.12.0
 snowballstemmer==1.2.1
 Sphinx==1.8.4
 sphinxcontrib-websupport==1.1.0
-urllib3==1.24.1
+urllib3>=1.24.2


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
Fixing this warning:
![image](https://user-images.githubusercontent.com/47524/56485198-c0657200-64db-11e9-9ba1-5024ad95ec8e.png)

### Changes made:
1. Update `urlib3` version to `>=1.24.2`

### Mentions:
I don't think we should stop pinning versions, but it seems this will happen on regular basis :( as we saw with #54 as well.
