### PR TITLE
Fixing urllib3 because 1.25 causes issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ six==1.12.0
 snowballstemmer==1.2.1
 Sphinx==1.8.4
 sphinxcontrib-websupport==1.1.0
-urllib3>=1.24.2
+urllib3==1.24.2


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
It seems I introduced an error with #56, thus I am fixing it.

The error as reported by @norling :
Replicated on Python 3.6.6
`pip freeze | grep -v "^-e" | xargs pip uninstall -y`
`pip install -r requirements.txt`

Error log:
```
ERROR: requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25 which is incompatible.
ERROR: botocore 1.12.134 has requirement urllib3<1.25,>=1.20; python_version >= "3.4", but you'll have urllib3 1.25 which is incompatible.
Installing collected packages: pika, chardet, idna, multidict, yarl, async-timeout, attrs, idna-ssl, aiohttp, Pygments, alabaster, pytz, Babel, pyparsing, six, packaging, certifi, urllib3, requests, snowballstemmer, MarkupSafe, Jinja2, sphinxcontrib-websupport, docutils, imagesize, Sphinx, sphinx-rtd-theme, asn1crypto, pycparser, cffi, cryptography, singledispatch, pyasn1, pgpy, psycopg2-binary, PyYaml, python-dateutil, jmespath, botocore, s3transfer, boto3, future, commonmark, recommonmark, terminaltables, docopt, legacryptor
Successfully installed Babel-2.6.0 Jinja2-2.10.1 MarkupSafe-1.1.0 PyYaml-5.1 Pygments-2.3.1 Sphinx-1.8.4 aiohttp-3.3.2 alabaster-0.7.12 asn1crypto-0.24.0 async-timeout-3.0.1 attrs-19.1.0 boto3-1.9.134 botocore-1.12.134 certifi-2018.11.29 cffi-1.12.3 chardet-3.0.4 commonmark-0.8.1 cryptography-2.3.1 docopt-0.6.2 docutils-0.14 future-0.17.1 idna-2.8 idna-ssl-1.1.0 imagesize-1.1.0 jmespath-0.9.4 legacryptor-1 multidict-4.5.2 packaging-19.0 pgpy-0.4.3 pika-0.12.0 psycopg2-binary-2.7.5 pyasn1-0.4.5 pycparser-2.19 pyparsing-2.3.1 python-dateutil-2.8.0 pytz-2018.9 recommonmark-0.5.0 requests-2.21.0 s3transfer-0.2.0 singledispatch-3.4.0.3 six-1.12.0 snowballstemmer-1.2.1 sphinx-rtd-theme-0.4.3 sphinxcontrib-websupport-1.1.0 terminaltables-3.1.0 urllib3-1.25 yarl-1.3.0
```

### Changes made:
1. Fix `urllib3==1.24.2`

### Related issues:

Fixes #58 

### Additional information:

What happened with the dependecies
1. `urllib3` released a package on 17th of April version `1.24.2` and another version 22nd of April `1.25`
2. `botocore` updated their version on the 19th of April, assuming to keep up with `urllib3`
3. `requests` set `urllib3` to `urllib3>=1.21.1,<1.25` about 6 months ago, also it has not been updated since December 2018
4. I changed the version as to GitHub recommendation https://github.com/EGA-archive/LocalEGA/pull/56 to `urllib3>=1.24.2`