### PR TITLE
Using PYTHONEXEC consistently across the bootstrap scripts

### DIFF
--- a/deploy/bootstrap/defs.sh
+++ b/deploy/bootstrap/defs.sh
@@ -58,7 +58,7 @@ function generate_password {
     fi
     # Otherwise
     local size=${1:-16} # defaults to 16 characters
-    ${PYTHONEXEC:-python3.6} -c "import secrets,string;print(''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(${size})))"
+    ${PYTHONEXEC} -c "import secrets,string;print(''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(${size})))"
 }
 
 function generate_mq_hash {

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -77,7 +77,7 @@ exec 2>${PRIVATE}/.err
 
 if [[ ${REAL_CEGA} != 'yes' ]]; then
     # Reset the variables here
-    CEGA_CONNECTION_PARAMS=$(python -c "from urllib.parse import urlencode;                               \
+    CEGA_CONNECTION_PARAMS=$(${PYTHONEXEC} -c "from urllib.parse import urlencode;                               \
 	  			        print(urlencode({ 'heartbeat': 0,                                 \
 				                          'connection_attempts': 30,                      \
 				                          'retry_delay': 10,                              \
@@ -214,7 +214,7 @@ keyserver_endpoint = http://keys${HOSTNAME_DOMAIN}:8080/keys/retrieve/%s/private
 EOF
 
 # Local broker connection
-MQ_CONNECTION_PARAMS=$(python -c "from urllib.parse import urlencode;                   \
+MQ_CONNECTION_PARAMS=$(${PYTHONEXEC} -c "from urllib.parse import urlencode;                   \
 			          print(urlencode({ 'heartbeat': 0,                     \
 				                    'connection_attempts': 30,          \
 				                    'retry_delay': 10,                  \
@@ -227,7 +227,7 @@ MQ_CONNECTION_PARAMS=$(python -c "from urllib.parse import urlencode;           
 MQ_CONNECTION="amqps://${MQ_USER}:${MQ_PASSWORD}@mq${HOSTNAME_DOMAIN}:5671/%2F"
 
 # Database connection
-DB_CONNECTION_PARAMS=$(python -c "from urllib.parse import urlencode;                   \
+DB_CONNECTION_PARAMS=$(${PYTHONEXEC} -c "from urllib.parse import urlencode;                   \
 			          print(urlencode({ 'application_name': 'LocalEGA',     \
 				                    'sslmode': 'verify-full',           \
 				                    'sslcert': '/etc/ega/ssl.cert',     \


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In some places, I had forgotten to use `${PYTHONEXEC}`, and used `python`.

### Changes made:
Basically `s/python/${PYTHONEXEC}/g`

### Related issues:
#67 

### Additional information:
Eventhough we call `${PYTHONEXEC}` everywhere, the issue is that the python code imports packages that do not exist in the standard library for `python2.7`, namely `secrets`.
Maybe they can be imported manually _before_ running the bootstrap.

The use of `${PYTHONEXEC}` was to allow the bootstrap to point to another python3 location, not to make it `python2.7`-compatible. (We won't support the latter).
