### PR TITLE
Fix TLS for Minio

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -269,6 +269,7 @@ s3_url = https://archive${HOSTNAME_DOMAIN}:9000
 s3_access_key = ${S3_ACCESS_KEY}
 s3_secret_key = ${S3_SECRET_KEY}
 #region = lega
+cacertfile = /etc/ega/CA.cert
 EOF
 else
     # POSIX file system

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -609,7 +609,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
       - MINIO_SECRET_KEY=${S3_SECRET_KEY_INBOX}
       - ../bootstrap/certs/data/inbox-s3-backend.cert.pem:/root/.minio/certs/public.crt
       - ../bootstrap/certs/data/inbox-s3-backend.sec.pem:/root/.minio/certs/private.key
-      - ../bootstrap/certs/data/CA.inbox-s3-backend.cert.pem:/home/.minio/CAs/LocalEGA.crt
+      - ../bootstrap/certs/data/CA.inbox-s3-backend.cert.pem:/root/.minio/CAs/LocalEGA.crt
     volumes:
       - inbox-s3:/data
     restart: on-failure:3

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -265,7 +265,7 @@ EOF
 if [[ ${ARCHIVE_BACKEND} == 's3' ]]; then
     cat >> ${PRIVATE}/conf.ini <<EOF
 storage_driver = S3Storage
-s3_url = http://archive${HOSTNAME_DOMAIN}:9000
+s3_url = https://archive${HOSTNAME_DOMAIN}:9000
 s3_access_key = ${S3_ACCESS_KEY}
 s3_secret_key = ${S3_SECRET_KEY}
 #region = lega
@@ -283,7 +283,7 @@ if [[ ${INBOX_BACKEND} == 's3' ]]; then
 
 [inbox]
 storage_driver = S3Storage
-url = http://inbox-s3-backend${HOSTNAME_DOMAIN}:9000
+url = https://inbox-s3-backend${HOSTNAME_DOMAIN}:9000
 access_key = ${S3_ACCESS_KEY_INBOX}
 secret_key = ${S3_SECRET_KEY_INBOX}
 #region = lega

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -582,9 +582,9 @@ cat >> ${PRIVATE}/lega.yml <<EOF
       - MINIO_SECRET_KEY=${S3_SECRET_KEY}
     volumes:
       - archive:/data
-      - ../bootstrap/certs/data/archive.cert.pem:/home/.minio/public.crt
-      - ../bootstrap/certs/data/archive.sec.pem:/home/.minio/private.key
-      - ../bootstrap/certs/data/CA.archive.cert.pem:/home/.minio/CAs/LocalEGA.crt
+      - ../bootstrap/certs/data/archive.cert.pem:/root/.minio/certs/public.crt
+      - ../bootstrap/certs/data/archive.sec.pem:/root/.minio/certs/private.key
+      - ../bootstrap/certs/data/CA.archive.cert.pem:/root/.minio/CAs/LocalEGA.crt
     restart: on-failure:3
     networks:
       - lega
@@ -607,8 +607,8 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     environment:
       - MINIO_ACCESS_KEY=${S3_ACCESS_KEY_INBOX}
       - MINIO_SECRET_KEY=${S3_SECRET_KEY_INBOX}
-      - ../bootstrap/certs/data/inbox-s3-backend.cert.pem:/home/.minio/public.crt
-      - ../bootstrap/certs/data/inbox-s3-backend.sec.pem:/home/.minio/private.key
+      - ../bootstrap/certs/data/inbox-s3-backend.cert.pem:/root/.minio/certs/public.crt
+      - ../bootstrap/certs/data/inbox-s3-backend.sec.pem:/root/.minio/certs/private.key
       - ../bootstrap/certs/data/CA.inbox-s3-backend.cert.pem:/home/.minio/CAs/LocalEGA.crt
     volumes:
       - inbox-s3:/data

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -201,11 +201,12 @@ class S3Storage():
         region = CONF.get_value(config_section, 's3_region')
         access_key = CONF.get_value(config_section, 's3_access_key')
         secret_key = CONF.get_value(config_section, 's3_secret_key')
+        verify = CONF.get_value(config_section, 'cacertfile', default=None) or False
         self.s3 = boto3.client('s3',
                                endpoint_url=self.endpoint,
                                region_name=region,
-                               use_ssl=False,
-                               verify=False,
+                               use_ssl=self.endpoint.startswith('https'),
+                               verify=verify,
                                aws_access_key_id=access_key,
                                aws_secret_access_key=secret_key)
         # LOG.debug(f'S3 client: {self.s3!r}')


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Enables TLS for Minio.

### Changes made:
In `run.sh`
```
      - ../bootstrap/certs/data/inbox-s3-backend.cert.pem:/home/.minio/public.crt
      - ../bootstrap/certs/data/inbox-s3-backend.sec.pem:/home/.minio/private.key
      - ../bootstrap/certs/data/CA.inbox-s3-backend.cert.pem:/home/.minio/CAs/LocalEGA.crt
```
is replaced with
```
      - ../bootstrap/certs/data/inbox-s3-backend.cert.pem:/root/.minio/certs/public.crt
      - ../bootstrap/certs/data/inbox-s3-backend.sec.pem:/root/.minio/certs/private.key
      - ../bootstrap/certs/data/CA.inbox-s3-backend.cert.pem:/root/.minio/CAs/LocalEGA.crt
```

And the same for vault (archive) Minio.

### Related issues:
Fixes https://github.com/EGA-archive/LocalEGA/issues/69
