### PR TITLE
Fixing the TLS connection for boto3

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -269,6 +269,7 @@ s3_url = https://archive${HOSTNAME_DOMAIN}:9000
 s3_access_key = ${S3_ACCESS_KEY}
 s3_secret_key = ${S3_SECRET_KEY}
 #region = lega
+cacertfile = /etc/ega/CA.cert
 EOF
 else
     # POSIX file system

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -201,11 +201,12 @@ class S3Storage():
         region = CONF.get_value(config_section, 's3_region')
         access_key = CONF.get_value(config_section, 's3_access_key')
         secret_key = CONF.get_value(config_section, 's3_secret_key')
+        verify = CONF.get_value(config_section, 'cacertfile', default=None) or False
         self.s3 = boto3.client('s3',
                                endpoint_url=self.endpoint,
                                region_name=region,
-                               use_ssl=False,
-                               verify=False,
+                               use_ssl=self.endpoint.startswith('https'),
+                               verify=verify,
                                aws_access_key_id=access_key,
                                aws_secret_access_key=secret_key)
         # LOG.debug(f'S3 client: {self.s3!r}')


### PR DESCRIPTION
Updating the boto3 client call, to use the configuration settings about TLS.

This enables encryption, and server verification.
Client verification is trickier and I'm currently on it.
You can already merge that part if you wish, and I'll make another PR with the client verification, or you leave #71 open for a little longer.

Note: I am aware about the warning:
```/usr/local/lib/python3.6/site-packages/urllib3/connection.py:362: SubjectAltNameWarning: Certificate for archive has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)```
This is a separate concern, it has to do with the certificate generation.