### PR TITLE
S3 client verification

### DIFF
--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -270,6 +270,8 @@ s3_access_key = ${S3_ACCESS_KEY}
 s3_secret_key = ${S3_SECRET_KEY}
 #region = lega
 cacertfile = /etc/ega/CA.cert
+certfile = /etc/ega/ssl.cert
+keyfile = /etc/ega/ssl.key
 EOF
 else
     # POSIX file system


### PR DESCRIPTION
Client verification towards the S3 backend.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
* Adding the file paths to the conf.ini
* updating a parameter to the S3 client.

### Related issues:
#69 , #71 

### Additional information:
The code is enabled, but, honestly, it's hard to test it since I could not find how to enforce client verification in MinIO. I hope it's done, somehow, when specifying the combination of the 3 files: cacert, cert and key 🤞