### PR TITLE
Fix integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pika==1.0.1
 aiohttp==3.3.2
 sphinx_rtd_theme
-cryptography==2.3.1
+cryptography==2.6.1
 pgpy
 psycopg2-binary==2.7.5
 PyYaml


### PR DESCRIPTION
### Describe the pull request:

- [x] Bug fix

### Pull request long description:

pgpy depends on a newer version of cryptography then the one we pinned. Updating to a newer version fixes the pip installation of libraries. After this all the integration tests should work