### PR TITLE
Removed config assertion to enable config-file less config

### DIFF
--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -19,8 +19,6 @@ def get_connection(domain, blocking=True):
     heartbeat values are read from the CONF argument.
     So are the SSL options.
     """
-    assert domain in CONF.sections(), "Section not found in config file"
-
     LOG.info(f'Getting a connection to {domain}')
     params = CONF.get_value(domain, 'connection', raw=True)
     LOG.debug(f"Initializing a connection to: {params}")


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
We want to be able to config the entire application without referring to a config file.

The config lookup works by first checking for the <SECTION>_<VAR> env var and then looking for the specified <var> in the [<section>] of the config file. Checking for a specific section in the configuration then will only work if there is a configuration file, since sections are not a defined concept in the environment. The test is also unnecesary since the following var lookup will fail anyway if it's not present.


### Changes made:
Removed one assertion.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
