### PR TITLE
Vault consistency

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -36,15 +36,15 @@ clean-all: clean clean-volumes
 
 preflight-check:
 	@echo "Ensure the system is up"
-	sleep 80
+	sleep 20
 
-# Note: "sleep 80" will be replaced with a script that checks for open port, mq settings, etc.
+# Note: "sleep 20" will be replaced with a script that checks for open port, mq settings, etc.
 # It might be a good idea to run it in the same network as the containers.
 # docker run --rm -it --network=lega_lega \
 #        -v ${PWD}/bootstrap/ensure_system_up.sh:/ensure_system_up.sh \
 #        egarchive/lega-base /ensure_system_up.sh
 
-# For the moment, we simply do sleep 60, because we need
+# For the moment, we simply do sleep 20, because we need
 # the rabbitmq shovel to CentralEGA (the federated queue can be late, it doesn't hurt)
 
 

--- a/lega/utils/exceptions.py
+++ b/lega/utils/exceptions.py
@@ -83,6 +83,39 @@ class Checksum(FromUser):
         return 'Invalid {} checksum for the {} file: {}'.format(self.algo, 'original' if self.decrypted else 'encrypted', self.file)
 
 
+class SessionKeyDecryptionError(FromUser):
+    """Raised Exception when header decryption fails."""
+
+    def __init__(self, h):
+        """Initialize Checksum Exception."""
+        self.header = h.hex().upper()
+
+    def __str__(self):
+        """Return readable informal exception description."""
+        return 'Unable to decrypt header with master key'
+
+    def __repr__(self):
+        """Return readable technical exception description."""
+        return f'Unable to decrypt header with master key: {self.header}'
+
+
+# Is it really a user error?
+class SessionKeyAlreadyUsedError(FromUser):
+    """Raised Exception related a session key being already in use."""
+
+    def __init__(self, checksum):
+        """Initialize Checksum in Exception."""
+        self.checksum = checksum
+
+    def __str__(self):
+        """Return readable informal exception description."""
+        return 'Session key (likely) already used.'
+
+    def __repr__(self):
+        """Return the checksum of the session key already used."""
+        return f'Session key (likely) already used [checksum: {self.checksum}].'
+
+
 #############################################################################
 # Any other exception is caught by us
 #############################################################################

--- a/tests/_common/helpers.bash
+++ b/tests/_common/helpers.bash
@@ -200,3 +200,4 @@ function lega_ingest {
 
     lega_trigger_ingestion "${TESTUSER}" "${TESTFILE_UPLOADED}" $queue 30 10
 }
+

--- a/tests/integration/ingestion.bats
+++ b/tests/integration/ingestion.bats
@@ -73,9 +73,6 @@ function teardown() {
 # while the second one should be in the error queue
 
 @test "Do not ingest the same file twice" {
-    skip
-    # We skip it for the moment since the codebase is old
-    # and does not support this functionality
 
     TESTFILE=$(uuidgen)
     TESTFILE_ENCRYPTED="${TESTFILES}/${TESTFILE}.c4gh"
@@ -93,6 +90,9 @@ function teardown() {
     
     # Second time goes to error
     lega_trigger_ingestion "${TESTUSER}" "${TESTFILE_UPLOADED}.2" v1.files.error 30 10
+    [[ "$output" =~ "user: dummy" ]]
+    [[ "$output" =~ "filepath: ${upload_path}" ]]
+    [[ "$output" =~ "reason: Session key (likely) already used." ]]
 }
 
 # Ingesting a file not in Crypt4GH format


### PR DESCRIPTION
When a file is ingested, we fetch its session key and try to decrypt the body of the file with it.
Before doing the latter, we checks if the sha256 checksum of the session key is already contained in the database (for non-errored and non-cancelled files).

If so, we raise a User Error.
If not, we proceed with the decryption and store the checksum of the session key in the database. (Note, we are aware of the potential data-race there, but it is not a harmful one). 

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

One more tests has been enabled: Not ingesting twice the same file
