### PR TITLE
Fix tuple parsing in Yaml SafeLoader

### DIFF
--- a/lega/conf/__init__.py
+++ b/lega/conf/__init__.py
@@ -23,10 +23,14 @@ import stat
 from logging.config import fileConfig, dictConfig
 from pathlib import Path
 import yaml
+from yaml import SafeLoader as sf
+
 
 LOG_FILE = os.getenv('LEGA_LOG', None)
 CONF_FILE = os.getenv('LEGA_CONF', '/etc/ega/conf.ini')
 LOG = logging.getLogger(__name__)
+
+sf.add_constructor('tag:yaml.org,2002:python/tuple', lambda self, node: tuple(sf.construct_sequence(self, node)))
 
 
 def get_from_file(filepath, mode='rb', remove_after=False):
@@ -163,7 +167,7 @@ class Configuration(configparser.RawConfigParser):
         _logger = _here / f'loggers/{filename}.yaml'
         if _logger.exists():
             with open(_logger, 'r') as stream:
-                dictConfig(yaml.safe_load(stream))
+                dictConfig(yaml.load(stream, Loader=sf))
                 return _logger
 
         # Otherwise trying it as a path
@@ -174,7 +178,7 @@ class Configuration(configparser.RawConfigParser):
 
         if _filename.suffix in ('.yaml', '.yml'):
             with open(_filename, 'r') as stream:
-                dictConfig(yaml.safe_load(stream))
+                dictConfig(yaml.load(stream, Loader=sf))
                 return filename
 
         if _filename.suffix in ('.ini', '.INI'):


### PR DESCRIPTION
adding a consctructor for tuple to fix safeloader as it is missing it

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

When trying to parse tuple configuration for logging the following error occurs:
```
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/tuple'
in "/usr/local/lib/python3.6/site-packages/lega/conf/loggers/default.yaml", line 24, column 14
```

This PR aims to fix it.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix


### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. added the tuple constructor to SafeLoader

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Identified in neicnordic/LocalEGA repo

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@silverdaz for suggestion on the one-liner 
