### PR TITLE
Robust shovel

### DIFF
--- a/deploy/bootstrap/lega-entrypoint.sh
+++ b/deploy/bootstrap/lega-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
 
-if ! test -e /etc/ega/ssl.key.lega; then
-    cp /etc/ega/ssl.key /etc/ega/ssl.key.lega
-    chmod 400 /etc/ega/ssl.key.lega
-fi
+cp -f /etc/ega/ssl.key /etc/ega/ssl.key.lega
+chmod 400 /etc/ega/ssl.key.lega
 
 exec $@

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -12,12 +12,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # This will pin the package versions
 COPY requirements.txt /root/LocalEGA/requirements.txt
+RUN pip install --upgrade pip && \
+    pip install -r /root/LocalEGA/requirements.txt
+
 COPY setup.py /root/LocalEGA/setup.py
 COPY lega /root/LocalEGA/lega
-
-RUN pip install --upgrade pip && \
-    pip install -r /root/LocalEGA/requirements.txt && \
-    pip install /root/LocalEGA
+RUN pip install /root/LocalEGA
 
 
 ##########################

--- a/ingestion/lega/dispatcher.py
+++ b/ingestion/lega/dispatcher.py
@@ -92,6 +92,7 @@ def work(data):
 
         job_id, staging_info = job
         staging_info['accession_id'] = accession_id
+        staging_info.pop('type', None)
         LOG.info('Found job id %s for correlation_id %s and accession_id %s', job_id, correlation_id, accession_id)
 
         # Sanity check or crash

--- a/ingestion/lega/dispatcher.py
+++ b/ingestion/lega/dispatcher.py
@@ -92,7 +92,7 @@ def work(data):
 
         job_id, staging_info = job
         staging_info['accession_id'] = accession_id
-        staging_info.pop('type', None)
+        # keep the type, it is used by save2db
         LOG.info('Found job id %s for correlation_id %s and accession_id %s', job_id, correlation_id, accession_id)
 
         # Sanity check or crash

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,6 +69,9 @@ They require some knowledge on how the components are interconnected.
 - [x] MQ restarted, test delivery mode<br/>
       Expected outcome: queued tasks completed
 
+- [x] Central MQ restarted while LocalEGA shoveling the completion message<br/>
+      Expected outcome: queued tasks completed
+
 - [ ] Retry message 3 times if rejected before error or timeout<br/>
       Expected outcome: queued tasks completed
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [x] Code cleanup

### Pull request long description:
Adding a mechanism to not lose the messages when LocalEGA is using the shovel to CentralEGA and CentralEGA is down (for a while, after a restart, for example).

The messages were backed by an ephemeral queue, but they are now backed by a durable queue and a shovel moves them to Central EGA (with the right routing key) when the connection succeeds.

This is akin to a [(reverse) federated queue, but lower-level](https://www.rabbitmq.com/distributed.html#shovel) and we don't need credentials to the LocalEGA instances

One more test was added for it: Central EGA goes down when the ingestion is complete, and the message is not lost after the restart.