### PR TITLE
Increase key size to 4096

### DIFF
--- a/deploy/bootstrap/certs.cnf
+++ b/deploy/bootstrap/certs.cnf
@@ -56,7 +56,7 @@ emailAddress            = optional
 
 [ req ]
 # Options for the `req` tool (`man req`).
-default_bits        = 2048
+default_bits        = 4096
 distinguished_name  = req_distinguished_name
 string_mask         = utf8only
 

--- a/deploy/bootstrap/certs.mk
+++ b/deploy/bootstrap/certs.mk
@@ -77,7 +77,7 @@ DOMAIN_EMAIL := -dev.ega@crg.eu
 ###############################################
 ../private/certs/%.sec.pem: | ../private/certs
 	@echo "Creating $(@F)"
-	@$(OPENSSL) genpkey -algorithm RSA -out $@ 2>../private/.err
+	@$(OPENSSL) genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out $@ 2>../private/.err
 	@chmod 444 $@
 
 # 444 instead of 400 to solve permission issues when docker-compose is injecting the files


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This pull request increases the size of the generated keys in the bootstrap to 4096.
This is to avoid the error
`ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small (_ssl.c:3991)`
produced in versions of openssl with an increased security level configured. See
[Openssl security level](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_callback.html) 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
